### PR TITLE
fix(types): correct chooseFile return type to Promise<string>

### DIFF
--- a/iina/index.d.ts
+++ b/iina/index.d.ts
@@ -1761,15 +1761,14 @@ declare namespace IINA {
        * - `chooseDir`: choose a directory instead of a file.
        * - `allowedFileTypes`: specify a list of available file extensions.
        *   Files without these extensions will be disabled in the panel.
-       * @returns Full path of the chosen file or directory.
+       * @returns A Promise that resolves to the full path of the chosen file or directory.
        *
        * @example
        * ```js
-       * const path = utils.chooseFile("Please select a subtitle file", {
+       * const path = await utils.chooseFile("Please select a subtitle file", {
        *   allowedFileTypes: ["ass", "srt"],
        * });
        * core.subtitle.loadTrack(path);
-       * ```
        */
       chooseFile(
         title: string,
@@ -1777,7 +1776,7 @@ declare namespace IINA {
           chooseDir: boolean;
           allowedFileTypes: string[];
         }>,
-      ): string;
+      ): Promise<string>;
       /**
        * Write a password to the system keychain.
        * Can be used to store other sensitive information such as JWT tokens.


### PR DESCRIPTION
## Changes
- Changed `chooseFile()` return type from `string` to `Promise<string>`

## Reason
The Swift implementation shows this method is async (returns a Promise), but the TypeScript definitions have it down as synchronous. This causes TypeScript errors when using `await` with this method and IINA resolves the file as [object Promise] when not using await.

## Evidence
Swift implementation shows Promise-based behavior:
```swift
func chooseFile() -> Any {
    return createPromise { resolve, reject in
        // async operation
        resolve.call(withArguments: [result.path])
    }
}
```
Link to swift file:
- https://github.com/iina/iina/blob/84cc736666e77fc051e5785e1215eee7bb06f87f/iina/JavascriptAPIUtils.swift#L231